### PR TITLE
Problem dans l export json et yaml

### DIFF
--- a/zkfarmer/conf.py
+++ b/zkfarmer/conf.py
@@ -64,8 +64,9 @@ class ConfBase(object):
 
 class ConfJSON(ConfBase):
     def read(self):
-        with self.open() as fd:
-            return json.load(fd.read())
+        if os.path.exists(self.file_path):
+            with self.open() as fd:
+                return json.load(fd)
 
     def write(self, obj):
         try:
@@ -79,8 +80,9 @@ class ConfJSON(ConfBase):
 
 class ConfYAML(ConfBase):
     def read(self):
-        with self.open() as fd:
-            return yaml.load(fd.read())
+        if os.path.exists(self.file_path):
+            with self.open() as fd:
+                return yaml.load(fd)
 
     def write(self, obj):
         try:


### PR DESCRIPTION
Je suis tombé sur 2 problemes en faisant:
./bin/zkfarmer export /services/db toto.yaml (ou json)

1) comme le fichier n existe pas et que tu open() en mode 'r' ca fait une IOError
2) tu fais un json.load() en passant fd.read() alors que json.load() attend directement le filedescriptor

Il reste un bug, si le fichier .json ou .yaml est invalide a l origine genre un simple fichier vide pour le json.
Il faudrait try/except ValueError le json.load et yaml.load
