### PR TITLE
watcher: put hostname in `hostname` and use IP in ZK path

### DIFF
--- a/zkfarmer/watcher.py
+++ b/zkfarmer/watcher.py
@@ -10,6 +10,7 @@ import Queue
 import time
 import itertools
 import os
+from socket import gethostname
 
 import logging as _logging
 logger = _logging.getLogger(__name__)


### PR DESCRIPTION
Commit a1f98ab19cc9d68a79ab4fd20bf79f6d55a0d3b8 did replace the use of
hostname in "hostname" field populated by a joiner by its IP. We
revert this. Also, tests were incorrect in how `ip()` function was
mocked. We also correct this.
