### PR TITLE
zkfarmer: end ZK connection cleanly at exit

### DIFF
--- a/bin/zkfarmer
+++ b/bin/zkfarmer
@@ -230,6 +230,7 @@ def main():
             label = 'UNKNOWN'
 
         print '%s: %s' % (label, reason)
+        zkconn.close()
         exit(status)
 
     elif args.command == 'exec':
@@ -237,6 +238,8 @@ def main():
 
     else:
         parser.error('Unsupported command: %s' % args.command)
+
+    zkconn.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When exiting, close the connection to ZooKeeper. Otherwise, we may not
have stdout anymore and logging messages will raise an exception. An
easy what to show the problem is to use:

```
zkfarmer get /services/dbackup/10.35.2.3 backuplast | cat
```

It is likely that we get this exception:

```
1357639290
Exception in thread Thread-3 (most likely raised during interpreter shutdown
Traceback (most recent call last):
  File "/usr/lib/python2.6/threading.py", line 532, in __bootstrap_inner
  File "/usr/lib/python2.6/threading.py", line 484, in run
  File "/usr/lib/pymodules/python2.6/kazoo/protocol/connection.py", line 390
  File "/usr/lib/pymodules/python2.6/kazoo/protocol/connection.py", line 472
  File "/usr/lib/python2.6/socket.py", line 188, in close
<type 'exceptions.TypeError'>: 'NoneType' object is not callable
```
