### PR TITLE
zkfarmer: use `zkconn.stop()`, `zkconn.close()`

### DIFF
--- a/bin/zkfarmer
+++ b/bin/zkfarmer
@@ -230,7 +230,7 @@ def main():
             label = 'UNKNOWN'
 
         print '%s: %s' % (label, reason)
-        zkconn.close()
+        zkconn.stop()
         exit(status)
 
     elif args.command == 'exec':
@@ -239,7 +239,7 @@ def main():
     else:
         parser.error('Unsupported command: %s' % args.command)
 
-    zkconn.close()
+    zkconn.stop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The later is not available in stable versions of Kazoo...
