### PR TITLE
watcher: use a PriorityQueue

### DIFF
--- a/zkfarmer/watcher.py
+++ b/zkfarmer/watcher.py
@@ -32,7 +32,7 @@ class ZkFarmWatcher(object):
     EVENTS = {}
 
     def __init__(self, zkconn):
-        self.events = Queue.Queue()
+        self.events = Queue.PriorityQueue()
         self.counter = itertools.count()
         self.zkconn = zkconn
         self.zkconn.add_listener(self._zkchange)


### PR DESCRIPTION
Commit 839d24e61664b91a06ef972102111a9c550d6eb3 was meant to use a
priority queue. This is not the case, switch to priority queue. This
allows connection-related events to be handled earlier and discards a
few backtraces. This does not change the overall logic of the FSM.
