### PR TITLE
conf: don't overwrite a configuration file on serialization error

### DIFF
--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -5,6 +5,7 @@ import json
 import yaml
 import os
 import sys
+import stat
 
 from mock import patch
 from zkfarmer import conf
@@ -97,6 +98,26 @@ class TestConfJSON(TempDirectoryTestCase):
         # Write something invalid
         self.assertRaises(TypeError, a.write, json)
         self.assertEqual(a.read(), {"1": "2"})
+
+    def test_json_appropriate_rights(self):
+        """Check if a file is created with the appropriate rights"""
+        os.umask(022)
+        name = "%s/test.json" % self.tmpdir
+        a = conf.Conf(name)
+        a.write({"1": "2"})
+        del a
+        a = os.stat(name)
+        self.assertEqual(a.st_mode & 0777, 0644)
+
+    def test_json_appropriate_rights_umask(self):
+        """Check if a file is created with appropriate rights using non standard umask."""
+        os.umask(027)
+        name = "%s/test.json" % self.tmpdir
+        a = conf.Conf(name)
+        a.write({"1": "2"})
+        del a
+        a = os.stat(name)
+        self.assertEqual(a.st_mode & 0777, 0640)
 
 class TestConfYAML(TempDirectoryTestCase):
 

--- a/zkfarmer/conf.py
+++ b/zkfarmer/conf.py
@@ -73,12 +73,15 @@ class ConfFile(ConfBase):
             return
         tmp, tmpname = tempfile.mkstemp(dir=os.path.dirname(os.path.abspath(self.file_path)))
         try:
+            current_umask = os.umask(0)
+            os.umask(current_umask)
+            os.chmod(tmpname, 0666 & ~current_umask)
             f = os.fdopen(tmp, "w")
             yield f
             f.close()
             os.rename(tmpname, self.file_path)
         except:
-            os.unlink(tmp)
+            os.unlink(tmpname)
             raise
 
 class ConfJSON(ConfFile):


### PR DESCRIPTION
When a serilization error occurs, the resulting file is empty. We wrap
the file object to write to a temporary file and overwrite the file
only when the whole process has succeeded.

This only works for file-based backend (not directories). YAML is not tested because I didn't find out how to have a serialization error in YAML
