### PR TITLE
watcher: handle non-existent configuration file

### DIFF
--- a/tests/test_joiner.py
+++ b/tests/test_joiner.py
@@ -34,6 +34,13 @@ class TestZkJoiner(KazooTestCase):
         patcher.start().return_value = self.NAME
         self.addCleanup(patcher.stop)
 
+    def test_inexisting_conf(self):
+        """Test we can work when the configuration does not exist yet."""
+        self.conf.read.return_value = None
+        z = ZkFarmJoiner(self.client, "/services/db", self.conf)
+        z.loop(3, timeout=self.TIMEOUT)
+        self.conf.write.assert_called_with({"hostname": self.NAME})
+
     def test_initialize_observer(self):
         """Test if observer is correctly initialized"""
         self.conf.read.return_value = {}

--- a/zkfarmer/watcher.py
+++ b/zkfarmer/watcher.py
@@ -226,7 +226,7 @@ class ZkFarmJoiner(ZkFarmWatcher):
     def exec_initial_setup(self):
         """Non-zookeeper related initial setup"""
         # Force the hostname info key
-        info = self.conf.read()
+        info = self.conf.read() or {}
         info['hostname'] = gethostname()
         self.conf.write(info)
         self.mzxid = None


### PR DESCRIPTION
When a non-existent file is requested, the `Conf` object can return
`None` instead of an empty object. We handle this case and consider we
get an empty object instead.
