### PR TITLE
join: make join work on files and not just directories

### DIFF
--- a/tests/test_joiner.py
+++ b/tests/test_joiner.py
@@ -8,6 +8,10 @@ from zkfarmer.utils import create_filter
 from kazoo.testing import KazooTestCase
 from mock import Mock, patch
 
+class FakeEvent(object):
+    """Fake event for fake watchdog observer"""
+    src_path = "/fake/root"
+
 class TestZkJoiner(KazooTestCase):
 
     NAME = "zk-test"
@@ -39,7 +43,7 @@ class TestZkJoiner(KazooTestCase):
         self.conf.read.return_value = {}
         z = ZkFarmJoiner(self.client, "/services/db", self.conf)
         z.loop(3, timeout=self.TIMEOUT)
-        self.mock_observer.schedule.assert_called_once_with(z, path="/fake/root", recursive=True)
+        self.mock_observer.schedule.assert_called_once_with(z, path="/fake", recursive=True)
         self.mock_observer.start.assert_called_once_with()
 
     def test_set_hostname(self):
@@ -85,7 +89,7 @@ class TestZkJoiner(KazooTestCase):
         self.conf.reset_mock()
         self.conf.read.return_value = {"enabled": "0",
                                        "hostname": self.NAME}
-        z.dispatch("bogus modification")
+        z.dispatch(FakeEvent())
         z.loop(4, timeout=self.TIMEOUT)
         self.assertFalse(self.conf.write.called)
         self.assertEqual(json.loads(self.client.get("/services/db/%s" % self.IP)[0]),
@@ -140,7 +144,7 @@ class TestZkJoiner(KazooTestCase):
         self.conf.reset_mock()
         self.conf.read.return_value = {"enabled": "0",
                                        "hostname": self.NAME}
-        z.dispatch("local modification")
+        z.dispatch(FakeEvent())
         z.loop(4, timeout=self.TIMEOUT)
         self.assertFalse(self.conf.write.called)
         self.assertEqual(json.loads(self.client.get("/services/db/%s" % self.IP)[0]),
@@ -167,7 +171,7 @@ class TestZkJoiner(KazooTestCase):
         self.expire_session()
         self.conf.read.return_value = {"enabled": "22",
                                        "hostname": self.NAME}
-        z.dispatch("local modification")
+        z.dispatch(FakeEvent())
         z.loop(10, timeout=self.TIMEOUT)
         self.assertEqual(json.loads(self.client.get("/services/db/%s" % self.IP)[0]),
                          {"enabled": "22",
@@ -205,7 +209,7 @@ class TestZkJoiner(KazooTestCase):
         z = ZkFarmJoiner(self.client, "/services/db", self.conf)
         z.loop(3, timeout=self.TIMEOUT)
         self.expire_session()
-        z.dispatch("local modification")
+        z.dispatch(FakeEvent())
         self.conf.read.return_value = {"enabled": "56",
                                        "hostname": self.NAME}
         self.client.ensure_path("/services/db/%s" % self.IP) # Disconnected, the path does not exist
@@ -235,7 +239,7 @@ class TestZkJoiner(KazooTestCase):
         self.conf.read.return_value = {"enabled": "1",
                                        "hostname": self.NAME,
                                        "counter": 1001}
-        z.dispatch("local modification")
+        z.dispatch(FakeEvent())
         z.loop(1, timeout=self.TIMEOUT)
         # Here comes the local modification that won't be noticed now
         self.conf.reset_mock()

--- a/zkfarmer/watcher.py
+++ b/zkfarmer/watcher.py
@@ -233,7 +233,10 @@ class ZkFarmJoiner(ZkFarmWatcher):
 
         # Setup observer
         observer = Observer()
-        observer.schedule(self, path=self.conf.file_path, recursive=True)
+        path = self.conf.file_path
+        if not os.path.isdir(path):
+            path = os.path.dirname(os.path.realpath(path))
+        observer.schedule(self, path=path, recursive=True)
         observer.start()
 
         self.event("initial znode setup")
@@ -290,4 +293,5 @@ class ZkFarmJoiner(ZkFarmWatcher):
 
     def dispatch(self, event):
         """A local change has occured"""
-        self.event("local modified")
+        if event.src_path.startswith(self.conf.file_path):
+            self.event("local modified")


### PR DESCRIPTION
`watchdog.observer.Observer` is not able to watch a file. It needs to
watch a whole directory. We make it watch the parent directory and
check we only get notified for real changes for our file/directory.
