### PR TITLE
joiner: add an option to work with a common node

### DIFF
--- a/bin/zkfarmer
+++ b/bin/zkfarmer
@@ -46,6 +46,8 @@ def main():
     subparser.add_argument('conf', help='Path to the node configuration')
     subparser.add_argument('-f', '--format', dest='format', choices=['json', 'yaml', 'php', 'dir'],
                            help='set the configuration format')
+    subparser.add_argument('-c', '--common', dest='common', action='store_true',
+                           help='use a common zookeeper node instead of a dedicate node')
 
     # The `export' sub-command
     subparser = subparsers.add_parser('export', help='exports and maintain farm\'s nodes configuration',
@@ -184,7 +186,7 @@ def main():
         farmer.export(args.zknode, conf, updated_handler, args.filters)
 
     elif args.command == 'join':
-        farmer.join(args.zknode, conf)
+        farmer.join(args.zknode, conf, args.common)
 
     elif args.command == 'ls':
         fields = args.fields.split(',') if args.fields else []


### PR DESCRIPTION
In normal operations, each joiner will have its own zookeeper node. We
add an option to make them work on a common node instead. The hostname
is not added to the node and local modifications are not
authoritative. Moreover, the node is not ephemeral.
