### PR TITLE
joiner: handle file moved events as well

### DIFF
--- a/zkfarmer/watcher.py
+++ b/zkfarmer/watcher.py
@@ -293,5 +293,6 @@ class ZkFarmJoiner(ZkFarmWatcher):
 
     def dispatch(self, event):
         """A local change has occured"""
-        if event.src_path.startswith(self.conf.file_path):
+        if hasattr(event, "src_path") and event.src_path.startswith(self.conf.file_path) \
+           or hasattr(event, "dst_path") and event.dst_path.startswith(self.conf.file_path):
             self.event("local modified")


### PR DESCRIPTION
When a file is moved from one location to the target location, the
source location may not match what is required for the target
location (for example, when the target location is a file). We handle
this. This fixes a regression in 5c73ce.
