### PR TITLE
joiner: on some version of watchdog, the destination path is `dest_path`...

### DIFF
--- a/zkfarmer/watcher.py
+++ b/zkfarmer/watcher.py
@@ -294,5 +294,6 @@ class ZkFarmJoiner(ZkFarmWatcher):
     def dispatch(self, event):
         """A local change has occured"""
         if hasattr(event, "src_path") and event.src_path.startswith(self.conf.file_path) \
-           or hasattr(event, "dst_path") and event.dst_path.startswith(self.conf.file_path):
+           or hasattr(event, "dst_path") and event.dst_path.startswith(self.conf.file_path) \
+           or hasattr(event, "dest_path") and event.dest_path.startswith(self.conf.file_path):
             self.event("local modified")


### PR DESCRIPTION
..., not `dst_path`
