### PR TITLE
php: fix dumping of arrays with integers

### DIFF
--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -215,6 +215,14 @@ class TestConfPHP(TempDirectoryTestCase):
         self.assertRaises(TypeError, a.write, json)
         self.assertEqual(a.read(), {"1": "2"})
 
+    def test_php_write_list(self):
+        """Check we can write a list correctly."""
+        name = "%s/test.php" % self.tmpdir
+        a = conf.Conf(name, "php")
+        a.write({"something": [1,2,3]})
+        with open(name) as f:
+            self.assertIn('array(1,2,3)', f.read())
+
 class TestConfDir(TempDirectoryTestCase):
 
     def test_dir_from_existence(self):

--- a/zkfarmer/conf.py
+++ b/zkfarmer/conf.py
@@ -133,7 +133,7 @@ class ConfPHP(ConfFile):
             body = ',\n'.join(['%s"%s" => %s' % (indent + self.indent, self._quotemeta(key), self._dump(val, lvl + 1)) for key, val in value.items()])
             return 'array\n%s(\n%s\n%s)' % (indent, body, indent)
         elif type(value) == list:
-            return 'array(%s)' % ','.join([self._dump(val) for val in value])
+            return 'array(%s)' % ','.join([str(self._dump(val)) for val in value])
         else:
             raise TypeError('php_dump: cannot serialize value: %s' % type(value))
 


### PR DESCRIPTION
Python `join()` function only handles strings. We need to ensure that
we only provide strings.
