### PR TITLE
conf: don't use keyword `errors` for `str.encode`

### DIFF
--- a/zkfarmer/conf.py
+++ b/zkfarmer/conf.py
@@ -144,7 +144,7 @@ class ConfPHP(ConfFile):
     def write(self, obj):
         with self.open(write=True) as fd:
             php = u'<?php return %s;' % self._dump(obj)
-            fd.write(php.encode("utf-8", errors="ignore"))
+            fd.write(php.encode("utf-8", "ignore"))
 
 
 class ConfDir(ConfFile):


### PR DESCRIPTION
This is not supported with Python 2.6. Just use it as a positional
argument.
