### PR TITLE
joiner: add ability to execute a command on remote change

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Usage for the `zkfarmer join` command:
       -h, --help            show this help message and exit
       -f {json,yaml,php,dir}, --format {json,yaml,php,dir}
                             set the configuration format
+      --changed-cmd CMD     a command to be executed each time the configuration
+                            change
       -c, --common          use a common zookeeper node instead of a dedicated node
 
 Syncing Farm Configuration

--- a/bin/zkfarmer
+++ b/bin/zkfarmer
@@ -49,6 +49,8 @@ def main():
     subparser.add_argument('conf', help='Path to the node configuration')
     subparser.add_argument('-f', '--format', dest='format', choices=['json', 'yaml', 'php', 'dir'],
                            help='set the configuration format')
+    subparser.add_argument('--changed-cmd', dest='changed_cmd', metavar='CMD',
+                           help='a command to be executed each time the configuration change')
     subparser.add_argument('-c', '--common', dest='common', action='store_true',
                            help='use a common zookeeper node instead of a dedicated node')
 
@@ -201,7 +203,10 @@ def main():
         farmer.export(args.zknode, conf, updated_handler, args.filters)
 
     elif args.command == 'join':
-        farmer.join(args.zknode, conf, args.common)
+        def updated_handler():
+            if args.changed_cmd:
+                os.system(args.changed_cmd)
+        farmer.join(args.zknode, conf, args.common, updated_handler)
 
     elif args.command == 'import':
         farmer.importer(args.zknode, conf, args.common)

--- a/zkfarmer/watcher.py
+++ b/zkfarmer/watcher.py
@@ -289,6 +289,12 @@ class ZkFarmImporter(ZkFarmWatcher):
 
 class ZkFarmJoiner(ZkFarmImporter):
 
+    def __init__(self, zkconn, root_node_path, conf, common=False,
+                 updated_handler=None):
+        self.updated_handler = updated_handler
+        super(ZkFarmJoiner, self).__init__(zkconn, root_node_path,
+                                           conf, common)
+
     def watch_node(self, what):
         self.event("znode modified")
 
@@ -299,6 +305,8 @@ class ZkFarmJoiner(ZkFarmImporter):
         if not self.common:
             info['hostname'] = gethostname()
         self.conf.write(info)
+        if self.updated_handler:
+            self.updated_handler()
 
         super(ZkFarmJoiner, self).exec_initial_setup()
 
@@ -331,5 +339,7 @@ class ZkFarmJoiner(ZkFarmImporter):
                 logger.debug('Previous conf: %r' % current_conf)
                 logger.debug('New conf:      %r' % new_conf)
                 self.conf.write(new_conf)
+                if self.updated_handler:
+                    self.updated_handler()
         except NoNodeError:
             logger.warn("not able to watch for node %s: not exist anymore" % self.node_path)

--- a/zkfarmer/zkfarmer.py
+++ b/zkfarmer/zkfarmer.py
@@ -20,7 +20,7 @@ class ZkFarmer(object):
     def __init__(self, zkconn):
         self.zkconn = zkconn
 
-    def join(self, zknode, conf, common=False):
+    def join(self, zknode, conf, common=False, updated_handler=None):
         # Create farms ZkNode if doesn't already exists
         self.zkconn.retry(self.zkconn.ensure_path, zknode, acl=OPEN_ACL_UNSAFE)
         # If we are going to enlarged the farm max seen size, store it
@@ -29,7 +29,8 @@ class ZkFarmer(object):
             if current_size > self.get(zknode, 'size'):
                 self.set(zknode, 'size', current_size)
         # Join the farm
-        ZkFarmJoiner(self.zkconn, zknode, conf, common).loop(ignore_unknown_transitions=True)
+        ZkFarmJoiner(self.zkconn, zknode, conf, common,
+                     updated_handler).loop(ignore_unknown_transitions=True)
 
     def importer(self, zknode, conf, common=False):
         ZkFarmImporter(self.zkconn, zknode, conf, common).loop(ignore_unknown_transitions=True)


### PR DESCRIPTION
This is the same ability offered by the exporter. Since the joiner is
both an importer and an exporter, it makes sense for the joiner to also
be able to execute commands on configuration change.

There is also an unrelated commit to fix a typo in README.
